### PR TITLE
implement normalization constant for discrete truncated power law

### DIFF
--- a/powerlaw.py
+++ b/powerlaw.py
@@ -1223,7 +1223,10 @@ class Truncated_Power_Law(Distribution):
 
     @property
     def _pdf_discrete_normalizer(self):
-        return False
+        from mpmath import lerchphi
+        from mpmath import exp # faster /here/ than numpy.exp
+        C = float(exp(self.xmin * self.Lambda) / lerchphi(exp(-self.Lambda), self.alpha, self.xmin))
+        return C
 
     def pdf(self, data=None):
         if data==None and hasattr(self, 'parent_Fit'):


### PR DESCRIPTION
The directly computable normalization constant significantly reduces
the runtime for fitting a discrete truncated power law.

For a discrete truncated power law of form f(x) = x^-a_e^(-l_x), the
normalization constant C such that that sum of C_f(x) from x=xmin to
x=Infinity equals 1 is
   C = e^(l_xmin) / Phi(e^-l, a, xmin),
where Phi is the Lerch transcendent (aka Lerch Phi) function.
