### PR TITLE
fix cumulative_distribution_function to more closely match plfit and all...

### DIFF
--- a/powerlaw.py
+++ b/powerlaw.py
@@ -1,3 +1,9 @@
+# -*- coding: utf-8 -*-
+from __future__ import (print_function, absolute_import,
+                        unicode_literals, division)
+import six
+
+
 #The MIT License (MIT)
 #
 #Copyright (c) 2013 Jeff Alstott
@@ -100,7 +106,7 @@ class Fit(object):
             from numpy import sort
             self.data = sort(self.data)
 
-        self.fitting_cdf_bins, self.fitting_cdf = cdf(self.data, xmin=None, xmax=self.xmax)
+        self.fitting_cdf_bins, self.fitting_cdf = cdf(self.data, xmin=None, xmax=self.xmax, discrete=discrete)
 
         if xmin and type(xmin)!=tuple and type(xmin)!=list:
             self.fixed_xmin = True
@@ -361,9 +367,9 @@ class Fit(object):
             xmin = self.xmin
             xmax = self.xmax
         return cdf(data, xmin=xmin, xmax=xmax, survival=survival,
-                   **kwargs) 
-        return cdf(data, xmin=xmin, xmax=xmax, survival=survival,
-                   **kwargs) 
+                   discrete=self.discrete, **kwargs) 
+#        return cdf(data, xmin=xmin, xmax=xmax, survival=survival,
+#                   **kwargs) 
 
     def ccdf(self, original_data=False, survival=True, **kwargs):
         """
@@ -396,7 +402,7 @@ class Fit(object):
             xmin = self.xmin
             xmax = self.xmax
         return cdf(data, xmin=xmin, xmax=xmax, survival=survival,
-                   **kwargs)
+                   discrete=self.discrete, **kwargs)
 
     def pdf(self, original_data=False, **kwargs):
         """
@@ -668,7 +674,7 @@ class Distribution(object):
             Actual_CDF -= dropped_probability
             Actual_CDF /= 1-dropped_probability
         else:
-            bins, Actual_CDF = cdf(data)
+            bins, Actual_CDF = cdf(data, discrete=self.discrete)
 
         Theoretical_CDF = self.cdf(bins)
 
@@ -1666,7 +1672,7 @@ def ccdf(data, survival=True, **kwargs):
 
 def cumulative_distribution_function(data,
     xmin=None, xmax=None,
-    survival=False, **kwargs):
+    survival=False, discrete=False, **kwargs):
     """
     The cumulative distribution function (CDF) of the data.
 
@@ -1700,9 +1706,10 @@ def cumulative_distribution_function(data,
     n = float(len(data))
     from numpy import sort
     data = sort(data)
-    all_unique = not( any( data[:-1]==data[1:] ) )
+#    all_unique = not( any( data[:-1]==data[1:] ) )
 
-    if all_unique:
+#    if all_unique:
+    if not discrete:
         from numpy import arange
         CDF = arange(n)/n
     else:

--- a/testing/test_powerlaw.py
+++ b/testing/test_powerlaw.py
@@ -112,11 +112,11 @@ class FirstTestCase(unittest.TestCase):
             results[k]['alpha'] = fit.alpha
             results[k]['xmin'] = fit.xmin
 
-            #assert_allclose(fit.alpha, references[k]['alpha'],
-            #        rtol=rtol, atol=atol, err_msg=k)
+            assert_allclose(fit.alpha, references[k]['alpha'],
+                    rtol=rtol, atol=atol, err_msg=k)
 
-            #assert_allclose(fit.xmin, references[k]['xmin'],
-            #        rtol=rtol, atol=atol, err_msg=k)
+            assert_allclose(fit.xmin, references[k]['xmin'],
+                    rtol=rtol, atol=atol, err_msg=k)
 
     def test_lognormal(self):
         print("Testing lognormal fits")


### PR DESCRIPTION
...ow powerlaw distribution tests to pass

Jeff,

I noticed that the asserts in the test were all commented out. I uncommented the tests for the powerlaw fit and found that some did not work. After comparing to the plfit code, I noticed a difference in how the cumulative_distribution_function worked. I changed it to more closely match the plfit code and the tests now pass.