### PR TITLE
speed up tests by adding setupClass function so fits are only done once

### DIFF
--- a/testing/test_powerlaw.py
+++ b/testing/test_powerlaw.py
@@ -1,7 +1,12 @@
+# -*- coding: utf-8 -*-
+from __future__ import (print_function, absolute_import,
+                        unicode_literals, division)
+
 import unittest
 import powerlaw
 from numpy.testing import assert_allclose
 from numpy import genfromtxt
+
 
 references = {
         'words': {
@@ -40,7 +45,7 @@ references = {
             'alpha': 2.37,
             'xmin': 52.46,
             'lognormal': (-0.090, 0.93),
-            'exponential': (3.65,0.0),
+            'exponential': (3.65, 0.0),
             'stretched_exponential': (0.204, 0.84),
             'truncated_power_law': (-0.123, 0.62),
             },
@@ -67,8 +72,8 @@ references = {
         'quakes': {
             'discrete': False,
             'data': (10**genfromtxt('reference_data/quakes.txt'))/10**3,
-            'alpha': 1.64,
-            'xmin': .794,
+            'alpha': 1.95,   # Clauset/plfit value is 1.64
+            'xmin': 10,      # Clauset/plfit value is .794
             'lognormal': (-7.14, 0.0),
             'exponential': (11.6, 0.0),
             'stretched_exponential': (-7.09, 0.0),
@@ -77,14 +82,27 @@ references = {
         'surnames': {
             'discrete': False,
             'data': genfromtxt('reference_data/surnames.txt')/10**3,
-            'alpha': 2.5,
-            'xmin': 111.92,
+            'alpha': 2.2,       # Clauset/plfit value is 2.5,
+            'xmin': 14.92,      # Clauset/plfit value is 111.92
             'lognormal': (-0.836, 0.4),
             'exponential': (2.89, 0.0),
             'stretched_exponential': (-0.844, 0.40),
             'truncated_power_law': (-1.36, 0.10),
             }
         }
+"""
+There is a subtle bug in the Clauset/plfit code involving the calculation of
+the cumulative distribution function. Specifically, it assumes that only
+discrete distributions can have repeat values and therefore performs the
+calculation incorrectly in the case of a continuous distribution with repeated
+values as occurs in the quakes and surnames data sets. The alpha values used
+here for those data sets can be confirmed with the plfit code by forcing it use
+the corresponding xmin values. Forcing powerlaw to calculate the cumulative
+distribution function as done in the plfit code produces the same xmin values
+as the plfit code and the other data sets produce identical results with both
+plfit and powerlaw so the alpha and xmin values were changed as above for the
+quakes and surnames data sets.
+"""
 
 results = {
         'words': {},
@@ -97,7 +115,17 @@ results = {
         'surnames': {}
         }
 
+
 class FirstTestCase(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        for k in references.keys():
+            data = references[k]['data']
+            fit = powerlaw.Fit(data, discrete=references[k]['discrete'])
+            results[k]['alpha'] = fit.alpha
+            results[k]['xmin'] = fit.xmin
+            results[k]['fit'] = fit
 
     def test_power_law(self):
         print("Testing power law fits")
@@ -107,16 +135,11 @@ class FirstTestCase(unittest.TestCase):
 
         for k in references.keys():
             print(k)
-            data = references[k]['data']
-            fit = powerlaw.Fit(data, discrete=references[k]['discrete'])
-            results[k]['alpha'] = fit.alpha
-            results[k]['xmin'] = fit.xmin
+            assert_allclose(results[k]['alpha'], references[k]['alpha'],
+                            rtol=rtol, atol=atol, err_msg=k)
 
-            #assert_allclose(fit.alpha, references[k]['alpha'],
-            #        rtol=rtol, atol=atol, err_msg=k)
-
-            #assert_allclose(fit.xmin, references[k]['xmin'],
-            #        rtol=rtol, atol=atol, err_msg=k)
+            assert_allclose(results[k]['xmin'], references[k]['xmin'],
+                            rtol=rtol, atol=atol, err_msg=k)
 
     def test_lognormal(self):
         print("Testing lognormal fits")
@@ -126,15 +149,13 @@ class FirstTestCase(unittest.TestCase):
 
         for k in references.keys():
             print(k)
-            data = references[k]['data']
-            fit = powerlaw.Fit(data, discrete=references[k]['discrete'])
-
+            fit = results[k]['fit']
             Randp = fit.loglikelihood_ratio('power_law', 'lognormal',
-                    normalized_ratio=True)
+                                            normalized_ratio=True)
             results[k]['lognormal'] = Randp
 
             #assert_allclose(Randp, references[k]['lognormal'],
-            #        rtol=rtol, atol=atol, err_msg=k)
+                            #rtol=rtol, atol=atol, err_msg=k)
 
     def test_exponential(self):
         print("Testing exponential fits")
@@ -144,9 +165,7 @@ class FirstTestCase(unittest.TestCase):
 
         for k in references.keys():
             print(k)
-            data = references[k]['data']
-            fit = powerlaw.Fit(data, discrete=references[k]['discrete'])
-
+            fit = results[k]['fit']
             Randp = fit.loglikelihood_ratio('power_law', 'exponential',
                     normalized_ratio=True)
             results[k]['exponential'] = Randp
@@ -162,9 +181,7 @@ class FirstTestCase(unittest.TestCase):
 
         for k in references.keys():
             print(k)
-            data = references[k]['data']
-            fit = powerlaw.Fit(data, discrete=references[k]['discrete'])
-
+            fit = results[k]['fit']
             Randp = fit.loglikelihood_ratio('power_law', 'stretched_exponential',
                     normalized_ratio=True)
             results[k]['stretched_exponential'] = Randp
@@ -182,9 +199,7 @@ class FirstTestCase(unittest.TestCase):
             print(k)
             if references[k]['discrete']:
                 continue
-            data = references[k]['data']
-            fit = powerlaw.Fit(data, discrete=references[k]['discrete'])
-
+            fit = results[k]['fit']
             Randp = fit.loglikelihood_ratio('power_law', 'truncated_power_law')
             results[k]['truncated_power_law'] = Randp
 


### PR DESCRIPTION
Jeff,

here is a pass at increasing the speed of the tests by eliminating repetitive calculation of the fits. I changed the expected values of the powerlaw fits for the quakes and surnames data sets so the powerlaw tests would pass and added a comment explaining the change. The other tests remain commented out for now.

Larry