### PR TITLE
Fix lnorm

### DIFF
--- a/powerlaw.py
+++ b/powerlaw.py
@@ -1477,7 +1477,7 @@ class Lognormal(Distribution):
         if not self.discrete:
             f = self._pdf_base_function(data)
             C = self._pdf_continuous_normalizer
-            likelihoods = f*C
+            likelihoods = f/C
         else:
             if self._pdf_discrete_normalizer:
                 f = self._pdf_base_function(data)
@@ -1566,9 +1566,8 @@ class Lognormal(Distribution):
 #        from scipy.special import erfc
         from scipy.constants import pi
         from numpy import sqrt, log
-        C = ( sqrt(2/(pi*self.sigma**2)) /
-                erfc( (log(self.xmin)-self.mu) / (sqrt(2)*self.sigma))
-                )
+        C = (erfc((log(self.xmin) - self.mu) / (sqrt(2) * self.sigma)) /
+             sqrt(2/(pi*self.sigma**2)))
         return float(C)
 
     @property

--- a/powerlaw.py
+++ b/powerlaw.py
@@ -1470,14 +1470,17 @@ class Lognormal(Distribution):
         data = trim_to_range(data, xmin=self.xmin, xmax=self.xmax)
         n = len(data)
         from sys import float_info
+        from numpy import tile
         if not self.in_range():
-            from numpy import tile
             return tile(10**float_info.min_10_exp, n)
 
         if not self.discrete:
             f = self._pdf_base_function(data)
             C = self._pdf_continuous_normalizer
-            likelihoods = f/C
+            if C > 0:
+                likelihoods = f/C
+            else:
+                likelihoods = tile(10**float_info.min_10_exp, n)
         else:
             if self._pdf_discrete_normalizer:
                 f = self._pdf_base_function(data)

--- a/testing/test_powerlaw.py
+++ b/testing/test_powerlaw.py
@@ -69,26 +69,26 @@ references = {
             'stretched_exponential': (-0.546, 0.59),
             'truncated_power_law': (-4.52, 0.0),
             },
-        'quakes': {
-            'discrete': False,
-            'data': (10**genfromtxt('reference_data/quakes.txt'))/10**3,
-            'alpha': 1.95,   # Clauset/plfit value is 1.64
-            'xmin': 10,      # Clauset/plfit value is .794
-            'lognormal': (-7.14, 0.0),
-            'exponential': (11.6, 0.0),
-            'stretched_exponential': (-7.09, 0.0),
-            'truncated_power_law': (-24.4, 0.0),
-            },
-        'surnames': {
-            'discrete': False,
-            'data': genfromtxt('reference_data/surnames.txt')/10**3,
-            'alpha': 2.2,       # Clauset/plfit value is 2.5,
-            'xmin': 14.92,      # Clauset/plfit value is 111.92
-            'lognormal': (-0.836, 0.4),
-            'exponential': (2.89, 0.0),
-            'stretched_exponential': (-0.844, 0.40),
-            'truncated_power_law': (-1.36, 0.10),
-            }
+#        'quakes': {
+#            'discrete': False,
+#            'data': (10**genfromtxt('reference_data/quakes.txt'))/10**3,
+#            'alpha': 1.95,   # Clauset/plfit value is 1.64
+#            'xmin': 10,      # Clauset/plfit value is .794
+#            'lognormal': (-7.14, 0.0),
+#            'exponential': (11.6, 0.0),
+#            'stretched_exponential': (-7.09, 0.0),
+#            'truncated_power_law': (-24.4, 0.0),
+#            },
+#        'surnames': {
+#            'discrete': False,
+#            'data': genfromtxt('reference_data/surnames.txt')/10**3,
+#            'alpha': 2.2,       # Clauset/plfit value is 2.5,
+#            'xmin': 14.92,      # Clauset/plfit value is 111.92
+#            'lognormal': (-0.836, 0.4),
+#            'exponential': (2.89, 0.0),
+#            'stretched_exponential': (-0.844, 0.40),
+#            'truncated_power_law': (-1.36, 0.10),
+#            }
         }
 """
 There is a subtle bug in the Clauset/plfit code involving the calculation of

--- a/testing/test_powerlaw.py
+++ b/testing/test_powerlaw.py
@@ -122,7 +122,8 @@ class FirstTestCase(unittest.TestCase):
     def setUpClass(cls):
         for k in references.keys():
             data = references[k]['data']
-            fit = powerlaw.Fit(data, discrete=references[k]['discrete'])
+            fit = powerlaw.Fit(data, discrete=references[k]['discrete'],
+                               estimate_discrete=False)
             results[k]['alpha'] = fit.alpha
             results[k]['xmin'] = fit.xmin
             results[k]['fit'] = fit
@@ -154,8 +155,8 @@ class FirstTestCase(unittest.TestCase):
                                             normalized_ratio=True)
             results[k]['lognormal'] = Randp
 
-            #assert_allclose(Randp, references[k]['lognormal'],
-                            #rtol=rtol, atol=atol, err_msg=k)
+            assert_allclose(Randp, references[k]['lognormal'],
+                            rtol=rtol, atol=atol, err_msg=k)
 
     def test_exponential(self):
         print("Testing exponential fits")

--- a/testing/test_powerlaw.py
+++ b/testing/test_powerlaw.py
@@ -69,26 +69,26 @@ references = {
             'stretched_exponential': (-0.546, 0.59),
             'truncated_power_law': (-4.52, 0.0),
             },
-#        'quakes': {
-#            'discrete': False,
-#            'data': (10**genfromtxt('reference_data/quakes.txt'))/10**3,
-#            'alpha': 1.95,   # Clauset/plfit value is 1.64
-#            'xmin': 10,      # Clauset/plfit value is .794
-#            'lognormal': (-7.14, 0.0),
-#            'exponential': (11.6, 0.0),
-#            'stretched_exponential': (-7.09, 0.0),
-#            'truncated_power_law': (-24.4, 0.0),
-#            },
-#        'surnames': {
-#            'discrete': False,
-#            'data': genfromtxt('reference_data/surnames.txt')/10**3,
-#            'alpha': 2.2,       # Clauset/plfit value is 2.5,
-#            'xmin': 14.92,      # Clauset/plfit value is 111.92
-#            'lognormal': (-0.836, 0.4),
-#            'exponential': (2.89, 0.0),
-#            'stretched_exponential': (-0.844, 0.40),
-#            'truncated_power_law': (-1.36, 0.10),
-#            }
+        'quakes': {
+            'discrete': False,
+            'data': (10**genfromtxt('reference_data/quakes.txt'))/10**3,
+            'alpha': 1.95,   # Clauset/plfit value is 1.64
+            'xmin': 10,      # Clauset/plfit value is .794
+            'lognormal': (-0.796, 0.43),     # Clauset value is (-7.14, 0.0)
+            'exponential': (11.6, 0.0),
+            'stretched_exponential': (-7.09, 0.0),
+            'truncated_power_law': (-24.4, 0.0),
+            },
+        'surnames': {
+            'discrete': False,
+            'data': genfromtxt('reference_data/surnames.txt')/10**3,
+            'alpha': 2.2,       # Clauset/plfit value is 2.5,
+            'xmin': 14.92,      # Clauset/plfit value is 111.92
+            'lognormal': (0.148, 0.88),     # Clauset value is (-0.836, 0.4)
+            'exponential': (2.89, 0.0),
+            'stretched_exponential': (-0.844, 0.40),
+            'truncated_power_law': (-1.36, 0.10),
+            }
         }
 """
 There is a subtle bug in the Clauset/plfit code involving the calculation of


### PR DESCRIPTION
There was a problem with the calculation of the discrete pdf that became evident with the words data set that took me a while to understand and fix. It basically involved errors where expressions like ((1 - 1e-50) - (1 - 1e-49)) were calculated as zero rather than as 9e-50. I also ran into a problem with the erfc in the denominator of the continuous pdf normalizer value going to zero that was more easily fixed. Finally, I had to update the lognorm target values for the quakes and surnames data.