### PR TITLE
pdf-distribution for values <1.  Bug.

### DIFF
--- a/powerlaw.py
+++ b/powerlaw.py
@@ -1964,6 +1964,7 @@ def pdf(data, xmin=None, xmax=None, linear_bins=False, **kwargs):
     if xmin<1: #Needed to include also data x<1 in pdf.
         hist, edges = histogram(data/xmin, bins, density=True)
         edges=edges*xmin # transform result back to original   
+        hist=hist/xmin # rescale hist, so that np.sum(hist*edges)==1
     else:
         hist, edges = histogram(data, bins, density=True)
     


### PR DESCRIPTION
Found a bug in my modification.
The sum of hist*edges will be now =1. 
Sorry, I didn't found it before.