### PR TITLE
[fit] Raise ValueError on multi-dimensional input data

### DIFF
--- a/powerlaw.py
+++ b/powerlaw.py
@@ -78,6 +78,9 @@ class Fit(object):
         from numpy import asarray
         self.data = asarray(self.data_original, dtype='float')
 
+        if self.data.ndim != 1:
+            raise ValueError("Input data must be one-dimensional")
+
         self.discrete = discrete
 
         self.fit_method = fit_method


### PR DESCRIPTION
Right now if you accidentally try to use multi-dimensional input data,
you get a very cryptic error message inside Distribution, complaining
that there are too many indices provided for the array inside
`ActualCDF`. Checking for this up front allows for easier debugging, and
a more obvious fix.