### PR TITLE
FIX: issue 99

### DIFF
--- a/powerlaw.py
+++ b/powerlaw.py
@@ -1929,7 +1929,7 @@ def trim_to_range(data, xmin=None, xmax=None, **kwargs):
         data = data[data<=xmax]
     return data
 
-def pdf(data, xmin=None, xmax=None, linear_bins=False, **kwargs):
+def pdf(data, xmin=None, xmax=None, linear_bins=False, bins=None, **kwargs):
     """
     Returns the probability density function (normalized histogram) of the
     data.
@@ -1968,8 +1968,8 @@ def pdf(data, xmin=None, xmax=None, linear_bins=False, **kwargs):
         xmax2=xmax
         xmin2=xmin
 
-    if 'bins' in kwargs.keys():
-        bins = kwargs.pop('bins')
+    if bins is not None:
+        bins = bins
     elif linear_bins:
         bins = range(int(xmin2), ceil(xmax2)+1)
     else:
@@ -2080,7 +2080,12 @@ def plot_pdf(data, ax=None, linear_bins=False, **kwargs):
     ax : matplotlib axis
         The axis to which the plot was made.
     """
-    edges, hist = pdf(data, linear_bins=linear_bins, **kwargs)
+    if 'bins' in kwargs.keys():
+        bins = kwargs.pop('bins')
+    else:
+        bins = None
+
+    edges, hist = pdf(data, linear_bins=linear_bins, bins=bins, **kwargs)
     bin_centers = (edges[1:]+edges[:-1])/2.0
     from numpy import nan
     hist[hist==0] = nan

--- a/testing/test_powerlaw.py
+++ b/testing/test_powerlaw.py
@@ -207,6 +207,38 @@ class FirstTestCase(unittest.TestCase):
             #assert_allclose(Randp, references[k]['truncated_power_law'],
             #        rtol=rtol, atol=atol, err_msg=k)
 
+class TestPlotPDF(unittest.TestCase):
+    def test_custom_bins(self):
+
+        import numpy as np
+        import powerlaw
+
+        import matplotlib.pyplot as plt
+
+        data = 1. / np.random.power(4., 1000)
+        fit = powerlaw.Fit(data)
+
+        # ax1 = fit.plot_pdf()
+        plt.figure()
+        bins = 2
+        ax = fit.plot_pdf(marker="*", bins=bins)
+        line = ax.lines[0]
+        assert len(line.get_xdata()) == bins
+        plt.close()
+
+        plt.figure()
+        bins = 10
+        ax = fit.plot_pdf(marker="*", bins=bins)
+        line = ax.lines[0]
+        assert len(line.get_xdata()) == bins
+        plt.close()
+
+
+
+
+
+
+
 if __name__ == '__main__':
     # execute all TestCases in the module
     unittest.main()


### PR DESCRIPTION
Fixes #99 

The bins keyword is popped in `plot_pdf` and given explicitly to the `pdf` function. As there is only 1 keyword available in the `pdf` function I thought that this would be the easiest solution. Otherwise I would not be sure how to pop the `bins` keyword globally from within the function. 
I have created a test that checks if the `bins` keyword works as expected but I was not sure about the naming conventions etc. So feel free to comment or edit!

