### PR TITLE
FIX: issue 98

### DIFF
--- a/powerlaw.py
+++ b/powerlaw.py
@@ -1165,6 +1165,9 @@ class Power_Law(Distribution):
         else:
             self.noise_flag=False
 
+        if self.parameter1_name is None or self.parameter1 is None:
+            self.parameters([self.alpha])
+
     def _initial_parameters(self, data):
         from numpy import log, sum
         return 1 + len(data)/sum(log(data / (self.xmin)))

--- a/testing/test_powerlaw.py
+++ b/testing/test_powerlaw.py
@@ -142,6 +142,15 @@ class FirstTestCase(unittest.TestCase):
             assert_allclose(results[k]['xmin'], references[k]['xmin'],
                             rtol=rtol, atol=atol, err_msg=k)
 
+    def test_power_law_params(self):
+        print("Testing if power law params are set correctly")
+
+        for k in references.keys():
+            print(k)
+            assert results[k]['fit'].power_law.parameter1 == results[k]['fit'].power_law.alpha
+            assert results[k]['fit'].power_law.parameter1_name == 'alpha'
+
+
     def test_lognormal(self):
         print("Testing lognormal fits")
 


### PR DESCRIPTION
Fixes #98 
Simple fix for missing update of parameter values for power_law distribution. I simply checked in the `fit` method of the `Power_Law` class if the parameters are set and otherwise called `self.parameters()` to set them correctly. The reason for this was that the different cases in `fit` method are quite complex and I did not go into them in detail.

I added a test for this in the existing test class. This behavior exists for all test datasets except for 'words'.