### PR TITLE
Fix for pickling problem

### DIFF
--- a/powerlaw.py
+++ b/powerlaw.py
@@ -26,6 +26,18 @@ import sys
 
 __version__ = "1.5"
 
+# This needs to be a list of the keys in the supported_distributions
+# attribute of the Fit class.  The __getattr__ method needs the list.
+# If it uses supported_distributions.keys(), then it gets into an
+# infinte loop when unpickling a Fit object.  Hence the need for a
+# separate list outside the scope of the Fit class.
+supported_distribution_list = ['power_law',
+                               'lognormal',
+                               'exponential',
+                               'truncated_power_law',
+                               'stretched_exponential',
+                               'lognormal_positive']
+
 class Fit(object):
     """
     A fit of a data set to various probability distributions, namely power
@@ -154,7 +166,7 @@ class Fit(object):
         self.n_tail = self.n + n_above_max
 
     def __getattr__(self, name):
-        if name in self.supported_distributions.keys():
+        if name in supported_distribution_list:
             #from string import capwords
             #dist = capwords(name, '_')
             #dist = globals()[dist] #Seems a hack. Might try import powerlaw; getattr(powerlaw, dist)

--- a/testing/test_powerlaw_pickle.py
+++ b/testing/test_powerlaw_pickle.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+from __future__ import (print_function, absolute_import,
+                        unicode_literals, division)
+
+from numpy.testing import assert_allclose
+from numpy import genfromtxt
+
+import walkobj as wo
+
+import unittest
+import powerlaw
+import pickle
+
+references = {
+        'words': {
+            'discrete': True,
+            'data': genfromtxt('reference_data/words.txt'),
+            'alpha': 1.95,
+            'xmin': 7,
+            'lognormal': (0.395, 0.69),
+            'exponential': (9.09, 0.0),
+            'stretched_exponential': (4.13, 0.0),
+            'truncated_power_law': (-0.899, 0.18),
+            },
+        'blackouts': {
+            'discrete': False,
+            'data': genfromtxt('reference_data/blackouts.txt')/10.0**3,
+            'alpha': 2.3,
+            'xmin': 230,
+            'lognormal': (-0.412, 0.68),
+            'exponential': (1.43, 0.15),    # Clauset value is (1.21, 0.23),
+            'stretched_exponential': (-0.417, 0.68),
+            'truncated_power_law': (-0.382, 0.38),
+            },
+        }
+"""
+There is a subtle bug in the Clauset/plfit code involving the calculation of
+the cumulative distribution function. Specifically, it assumes that only
+discrete distributions can have repeat values and therefore performs the
+calculation incorrectly in the case of a continuous distribution with repeated
+values as occurs in the quakes and surnames data sets. The alpha values used
+here for those data sets can be confirmed with the plfit code by forcing it use
+the corresponding xmin values. Forcing powerlaw to calculate the cumulative
+distribution function as done in the plfit code produces the same xmin values
+as the plfit code and the other data sets produce identical results with both
+plfit and powerlaw so the alpha and xmin values were changed as above for the
+quakes and surnames data sets.
+"""
+
+results = {
+    'words': {},
+    'blackouts': {}
+        }
+
+
+class FirstTestCase(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        for k in references.keys():
+            data = references[k]['data']
+            fit = powerlaw.Fit(data, discrete=references[k]['discrete'],
+                               estimate_discrete=False)
+            results[k]['alpha'] = fit.alpha
+            results[k]['xmin'] = fit.xmin
+            results[k]['fit'] = fit
+
+    def test_power_pickle_dump(self):
+        print("Testing power law object pickle")
+
+        for k in references.keys():
+            print(f"Test pickling of {k}")
+            fname = k + "-test.pkl"
+            with open(fname, "wb") as fid:
+                pickle.dump(results[k]['fit'], fid)
+            # print("I dumped")
+            # results[k]['fit'].supported_distributions.keys()
+
+    def test_power_pickle_load(self):
+        print("Testing power law object unpickle")
+
+        for k in references.keys():
+            print(f"Test unpickling of {k}")
+            fname = k + "-test.pkl"
+            with open(fname, "rb") as fid:
+                fitres = pickle.load(fid)
+            assert wo.typedtree(fitres) == wo.typedtree(results[k]['fit'])
+
+if __name__ == '__main__':
+    # execute all TestCases in the module
+    unittest.main()

--- a/testing/test_walkobj.py
+++ b/testing/test_walkobj.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+
+import unittest
+import numpy as np
+
+import walkobj as wo
+
+import walkobj as wo
+import numpy as np
+
+
+class MyClass:
+    def __init__(self, foo, bar):
+        self.foo = foo
+        self.bar = bar
+
+
+c1 = MyClass('foo', np.array([1, 2, 3]))
+c2 = MyClass('foo', np.array([1, 2, 3]))
+c3 = MyClass('food', np.array([1, 2, 3]))
+c4 = MyClass('foo', np.array([1, 2, 3, 4]))
+
+testvals = [("abc", "abcd", False),
+            (1, 1.0, True),
+            (1, 1.01, False),
+            (True, False, False),
+            (True, True, True),
+            (True, 1, True),
+            (True, 0, False),
+            (True, "abc", False),
+            (False, "abc", False),
+            (None, "abc", False),
+            (None, 1, False),
+            (None, 0, False),
+            (np.nan, True, False),
+            (np.nan, False, False),
+            (np.nan, 0, False),
+            (np.nan, np.nan, False),
+            ([1, 2, 3], [1, 2, 3], True),
+            ([1, 2, 3], [1, 2, 3, 4], False),
+            ([1, 2, 3], [1, 2], False),
+            ({"a": 1, "b": 2, "c": 3}, {"a": 1, "b": 2, "c": 3}, True),
+            ({"a": 1, "b": 2, "c": 3}, {"a": 1, "b": 2, "c": 3.01}, False),
+            ({"a": 1, "b": 2, "c": 3}, {"a": 1, "b": 2}, False),
+            ([c1, [c1, c2]], [c2, [c2, c1]], True),
+            ((c1, (c1, c2)), (c2, (c2, c1)), True),
+            ((c1, c2), (c2, c1), True),
+            (c1, c3, False),
+            ((c1, (c1, (c1, c4))), (c1, (c1, (c1, c3))), False)]
+
+
+def test_deep_equals(obja, objb, isequal):
+    """Confirm that equality of two objects is correct
+
+    obja    : One object
+    objb    : Second object
+    isequal : Whether or not they should be equal
+
+    Converts them to typedtrees and uses ==.
+
+    Returns True iff they have the right equality.
+
+    Note - This doesn't work for NaNs, as two NaNs are not considered equal
+    """
+
+    objatree = wo.typedtree(obja)
+    objbtree = wo.typedtree(objb)
+    match = objatree == objbtree
+    ok = match == isequal
+
+    if ok:
+        s = "pass"
+    else:
+        s = "fail"
+
+    print(f"{obja} == {objb} is {match} : {s}")
+    return ok
+
+
+class FirstTestCase(unittest.TestCase):
+
+    def test_power_pickle_dump(self):
+        print("Testing walkobj.typedtree equality for different objects")
+
+        for args in testvals:
+            assert test_deep_equals(*args) is True
+
+
+if __name__ == '__main__':
+    # execute all TestCases in the module
+    unittest.main()

--- a/testing/walkobj.py
+++ b/testing/walkobj.py
@@ -1,0 +1,78 @@
+"""walkobj - object walker module
+
+Functions for walking the tree of an object
+
+Usage:
+   Recursively print values of slots in a class instance obj:
+      walk(obj, print)
+   Recursively print values of all slots in a list of classes:
+      walk([obj1, obj2, ...], print)
+   Convert an object into a typed tree
+      typedtree(obj)
+
+A typed tree is a (recursive) list of the items in an object, prefixed by the type of the object
+"""
+
+from collections.abc import Iterable
+
+
+BASE_TYPES = [str, int, float, bool, type(None)]
+
+
+def atom(obj):
+    """Return true if object is a known atomic type.
+
+    obj : Object to identify
+
+    Known atomic types are strings, ints, floats, bools & type(None).
+    """
+    return type(obj) in BASE_TYPES
+
+
+def walk(obj, fun):
+    """Recursively walk object tree, applying a function to each leaf.
+
+    obj : Object to walk
+    fun : function to apply
+
+    A leaf is an atom (str, int, float, bool or None), or something
+    that is not a dictionary, a class instance or an iterable object.
+    """
+    if atom(obj):
+        fun(obj)
+    elif isinstance(obj, dict):
+        for keyobj in obj.items():
+            walk(keyobj, fun)
+    elif isinstance(obj, Iterable):
+        for item in obj:
+            walk(item, fun)
+    elif '__dict__' in dir(obj):
+        walk(obj.__dict__, fun)
+    else:
+        fun(obj)
+
+
+def typedtree(obj):
+    """Convert object to a typed nested list.
+
+    obj : Object to walk
+
+    Returns the object if it's an atom or unrecognized.
+
+    If it's a class, return the list [type(obj)] + nested list of the
+    object's slots (i.e., typedtree(obj.__dict__).
+
+    If it's iterable, return the list [type(obj)] + nested list of
+    items in list.
+
+    Otherwise, it's unrecognized and just returned as if it's an atom.
+    """
+    if atom(obj):
+        return obj
+    if isinstance(obj, dict):
+        return (dict, [typedtree(obj) for obj in obj.items()])
+    if isinstance(obj, Iterable):
+        return (type(obj), [typedtree(obj) for obj in obj])
+    if '__dict__' in dir(obj):
+        return (type(obj), typedtree(obj.__dict__))
+    return obj


### PR DESCRIPTION
This is a fix for issue #18 

The problem was that Fit.__getattr__() was getting into an infinite loop when unpickling a Fit object.  The problem was that when __getattr__ calls self.supported_distributions.keys(), it was triggering another call to __getattr__.  Evidently, this happens when unpickling but not otherwise because pickle.load() is building up the object, so more attributes are missing then in general.  In any case, the fix is to make a list of the keys that's outside the scope of the class, so that __getattr__ doesn't end up calling itself.

For testing that the pickling and unpickling is working, I added test_powerlaw_pickle.py, and walkobj.py.  The latter is used to convert a Fit object to a nested list so that the unpickled object can be compared to the original so as to confirm that the pickling is working correctly.